### PR TITLE
Mark Trigger or Entire Line

### DIFF
--- a/src/CredoParser.ts
+++ b/src/CredoParser.ts
@@ -3,17 +3,34 @@ import { CredoSeverity, CredoIssue, CredoOutput } from './CredoOutput';
 import { makeZeroBasedIndex } from './utilities';
 
 export default class CredoParser {
-  public static parseCredoOutput(credoOutput: CredoOutput): vscode.Diagnostic[] {
-    return credoOutput.issues.map((issue: CredoIssue) => this.parseCredoIssue(issue));
+  public static parseCredoOutput(credoOutput: CredoOutput, document: vscode.TextDocument): vscode.Diagnostic[] {
+    const documentContent = document.getText();
+    return credoOutput.issues.map((issue: CredoIssue) => this.parseCredoIssue(issue, documentContent));
   }
 
-  public static parseCredoIssue(issue: CredoIssue): vscode.Diagnostic {
-    const range = new vscode.Range(
-      makeZeroBasedIndex(issue.line_no),
-      makeZeroBasedIndex(issue.column),
-      makeZeroBasedIndex(issue.line_no),
-      makeZeroBasedIndex(issue.column_end),
-    );
+  public static parseCredoIssue(issue: CredoIssue, documentContent: string): vscode.Diagnostic {
+    const currentLine = documentContent.split('\n')[makeZeroBasedIndex(issue.line_no)];
+    let range;
+
+    if (issue.column === null && issue.column_end === null && currentLine) {
+      const columnStart = 0;
+      const columnEnd = makeZeroBasedIndex(currentLine.length);
+
+      range = new vscode.Range(
+        makeZeroBasedIndex(issue.line_no),
+        columnStart,
+        makeZeroBasedIndex(issue.line_no),
+        columnEnd,
+      );
+    } else {
+      range = new vscode.Range(
+        makeZeroBasedIndex(issue.line_no),
+        makeZeroBasedIndex(issue.column),
+        makeZeroBasedIndex(issue.line_no),
+        makeZeroBasedIndex(issue.column_end),
+      );
+    }
+
     const severity = this.parseSeverity(issue.category);
     const message = `${issue.message} (${issue.category}:${issue.check})`;
 

--- a/src/CredoParser.ts
+++ b/src/CredoParser.ts
@@ -13,7 +13,9 @@ export default class CredoParser {
     let range;
 
     if (issue.column === null && issue.column_end === null && currentLine) {
-      const columnStart = issue.trigger ? currentLine.indexOf(issue.trigger) : 0;
+      const columnStart = issue.trigger && currentLine.indexOf(issue.trigger) !== 1
+        ? currentLine.indexOf(issue.trigger)
+        : 0;
       const columnEnd = makeZeroBasedIndex(currentLine.length);
 
       range = new vscode.Range(

--- a/src/CredoParser.ts
+++ b/src/CredoParser.ts
@@ -13,7 +13,7 @@ export default class CredoParser {
     let range;
 
     if (issue.column === null && issue.column_end === null && currentLine) {
-      const columnStart = 0;
+      const columnStart = issue.trigger ? currentLine.indexOf(issue.trigger) : 0;
       const columnEnd = makeZeroBasedIndex(currentLine.length);
 
       range = new vscode.Range(

--- a/src/CredoProvider.ts
+++ b/src/CredoProvider.ts
@@ -45,7 +45,7 @@ export default class CredoProvider {
       const output = this.parse(stdout.toString());
       if (output === undefined || output === null) return;
 
-      this.diagnosticCollection.set(uri, CredoParser.parseCredoOutput(output));
+      this.diagnosticCollection.set(uri, CredoParser.parseCredoOutput(output, document));
 
       token.finished();
 


### PR DESCRIPTION
**Problem:**
Sometimes, parsed Credo issues do not contain valid values for `column` and `column_end`.
Then, only, the beginning of the line is marked by the diagnostic in VS Code.

**Solution:**
- If a `trigger` is present and the column identifiers are not, then only the `trigger`'s string should be marked in the line.
  - if the `trigger` is no substring in the specified line, then mark the entire line.
- If no `trigger` is present, mark the entire line instead.

Solves #1.