### PR TITLE
Change Severity of 'refactor' Issues to Information

### DIFF
--- a/src/CredoParser.ts
+++ b/src/CredoParser.ts
@@ -25,7 +25,7 @@ export default class CredoParser {
       case 'consistency': return vscode.DiagnosticSeverity.Warning;
       case 'design': return vscode.DiagnosticSeverity.Information;
       case 'readability': return vscode.DiagnosticSeverity.Information;
-      case 'refactor': return vscode.DiagnosticSeverity.Hint;
+      case 'refactor': return vscode.DiagnosticSeverity.Information;
       case 'warning': return vscode.DiagnosticSeverity.Warning;
       default: return vscode.DiagnosticSeverity.Error;
     }


### PR DESCRIPTION
**Problem:**
VS Code diagnostics with the severity `Hint` are not displayed noticeably, i.e. only 3 little yellow dots are below the issue's trigger and the hint is not displayed in the *Problems* panel at the bottom. 

**Solution:**
Change the severity of `'refactor'` issues to `Information`.

Mentioned in #1.