### PR TITLE
Add Configuration Option to Ignore Warning Messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-None
+### Added
+
+- Added a configuration option `ignoreWarningMessages` in order to be able to ignore the following warning messages (especially if they come repeatedly, see #4):
+  - "Found multiple files ... will use ..."
+  - "... file does not exist. Ignoring ..."
 
 ## [0.1.1] - 2020-11-24
 
@@ -21,7 +25,7 @@ None
 
 - Use credo issues' `trigger`s to mark the correct substring (#2)
 
-## Changed
+### Changed
 
 - Display `'refactor'` issues as `Information` instead of hints (#3).
   This allows the issues to be displayed more clearly and also shown in the `Problems` panel.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Improve warning message if the credo output is empty
+- Try to capture only the JSON-part of the credo output if it includes info messages from mix, for instance.
 
 ## [0.1.1] - 2020-11-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - "Found multiple files ... will use ..."
   - "... file does not exist. Ignoring ..."
 
+### Fixed
+
+- Improve warning message if the credo output is empty
+
 ## [0.1.1] - 2020-11-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This extension contributes the following settings:
 * `elixir.credo.credoConfiguration`: name of the configuration Credo should use. Uses the default configuration per default (`default`).
 * `elixir.credo.strictMode`: whether to utilize Credo's strict mode when linting.
 * `elixir.credo.executePath`: execute path of the `mix` executable
+* `elixir.credo.ignoreWarningMessages`: ignore warning messages (concerning finding the configuration file)
 
 ### Known Issues
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,12 @@
             "description": "Specifies whether to activate Credo's strict mode",
             "type": "boolean",
             "default": false
+          },
+          "elixir.credo.ignoreWarningMessages": {
+            "title": "Ignore Warning Messages",
+            "description": "Ignore messages \"Found multiple files ...\", \"... file does not exist. Ignoring ...\"",
+            "type": "boolean",
+            "default": false
           }
         }
       }

--- a/src/CredoConfiguration.ts
+++ b/src/CredoConfiguration.ts
@@ -4,4 +4,5 @@ export default interface CredoConfiguration {
   configurationFile: string;
   credoConfiguration: string | 'default';
   strictMode: boolean;
+  ignoreWarningMessages: boolean;
 }

--- a/src/CredoProvider.ts
+++ b/src/CredoProvider.ts
@@ -115,11 +115,13 @@ export default class CredoProvider {
     }
 
     try {
-      return JSON.parse(output);
+      const extractedJSON = output.substr(output.indexOf('{'));
+
+      return JSON.parse(extractedJSON);
     } catch (e) {
       if (e instanceof SyntaxError) {
         vscode.window.showWarningMessage(
-          `Error on parsing output (It might non-JSON output) : "${output.replace(/[\r\n \t]/g, ' ')}"`,
+          `Error on parsing output (It might be non-JSON output): "${output.replace(/[\r\n \t]/g, ' ')}"`,
         );
       }
 

--- a/src/CredoProvider.ts
+++ b/src/CredoProvider.ts
@@ -107,7 +107,8 @@ export default class CredoProvider {
   private parse(output: string): CredoOutput | null {
     if (output.length < 1) {
       vscode.window.showWarningMessage(
-        `command \`${this.config.command} credo\` returns empty output! please check configuration.`,
+        `command \`${this.config.command} credo\` returns empty output! please check configuration.
+        Did you add or modify your dependencies? You might need to run \`mix deps.get\` or recompile.`,
       );
 
       return null;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -38,5 +38,6 @@ export function getConfig(): CredoConfiguration {
     configurationFile: conf.get('configurationFile', '.credo.exs'),
     credoConfiguration: conf.get('credoConfiguration', 'default'),
     strictMode: conf.get('strictMode', false),
+    ignoreWarningMessages: conf.get('ignoreWarningMessages', false),
   };
 }

--- a/src/test/suite/CredoProvider.test.ts
+++ b/src/test/suite/CredoProvider.test.ts
@@ -24,6 +24,7 @@ describe('CredoProvider', () => {
           configurationFile: '.credo.exs',
           credoConfiguration: 'default',
           strictMode: false,
+          ignoreWarningMessages: false,
         }));
 
         it('returns true', () => {
@@ -41,6 +42,7 @@ describe('CredoProvider', () => {
           configurationFile: '.credo.exs',
           credoConfiguration: 'default',
           strictMode: false,
+          ignoreWarningMessages: false,
         }));
       });
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -40,9 +40,11 @@ export function getCommandArguments(): string[] {
   ).filter((p: string) => fs.existsSync(p));
 
   if (found.length === 0) {
-    vscode.window.showWarningMessage(`${configurationFile} file does not exist. Ignoring...`);
+    if (!extensionConfig.ignoreWarningMessages) {
+      vscode.window.showWarningMessage(`${configurationFile} file does not exist. Ignoring...`);
+    }
   } else {
-    if (found.length > 1) {
+    if (found.length > 1 && !extensionConfig.ignoreWarningMessages) {
       vscode.window.showWarningMessage(`Found multiple files (${found}) will use ${found[0]}`);
     }
     commandArguments.push(...['--config-file', found[0]]);


### PR DESCRIPTION
**Problem:**

Warning Message "Found multiple files ..." is shown repeatedly (reason unknown).

**Solution:**

Add configuration option `ignoreWarningMessages` to be able to ignore said warning message.

(Also improves other warning messages, and tries to capture only JSON-part of credo output)

Mentioned in #4.
