### PR TITLE
Support Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-None.
+### Added
+
+- Support this extension also on Windows platforms by using the mix executable `mix.bat`
 
 ## [0.2.0] - 2021-01-12
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,9 +1,11 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as os from 'os';
 import CredoConfiguration from './CredoConfiguration';
 
 const MIX_COMMAND = 'mix';
+const MIX_WINDOWS_COMMAND = 'mix.bat';
 
 export function autodetectExecutePath(): string {
   const conf = vscode.workspace.getConfiguration('elixir.credo');
@@ -22,7 +24,10 @@ export function autodetectExecutePath(): string {
   }
 
   pathParts.forEach((pathPart) => {
-    const binPath = path.join(pathPart, MIX_COMMAND);
+    const binPath = os.platform() === 'win32'
+      ? path.join(pathPart, MIX_WINDOWS_COMMAND)
+      : path.join(pathPart, MIX_COMMAND);
+
     if (fs.existsSync(binPath)) executePath = pathPart + path.sep;
   });
 

--- a/src/test/suite/configuration.test.ts
+++ b/src/test/suite/configuration.test.ts
@@ -1,32 +1,53 @@
 import { expect } from 'chai';
 import { createSandbox, SinonSandbox } from 'sinon';
 import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { autodetectExecutePath } from '../../configuration';
 
 describe('Configuration Functions', () => {
+  let sandbox: SinonSandbox;
   const OLD_ENV = { ...process.env };
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+  });
 
   afterEach(() => {
     process.env = OLD_ENV;
+    sandbox.restore();
   });
 
   context('#autodetectExecutePath', () => {
     context('with a valid execute path', () => {
-      const validPath = '/usr/bin/.asdf/shims';
-      let sandbox: SinonSandbox;
+      context('on a UNIX based OS', () => {
+        const validPath = '/usr/bin/.asdf/shims';
 
-      beforeEach(() => {
-        sandbox = createSandbox();
-        process.env.PATH = `${validPath}:/useless/path`;
-        sandbox.stub(fs, 'existsSync').withArgs(`${validPath}/mix`).returns(true);
+        beforeEach(() => {
+          process.env.PATH = `${validPath}:/useless/path`;
+          sandbox.stub(fs, 'existsSync').withArgs(`${validPath}/mix`).returns(true);
+        });
+
+        it('selects the first valid execute path for the mix command', () => {
+          expect(autodetectExecutePath()).to.equal(`${validPath}/`);
+        });
       });
 
-      afterEach(() => {
-        sandbox.restore();
-      });
+      context('on a windows platform', () => {
+        const validPath = 'C:\\Program Files (x86)\\Elixir\\bin';
 
-      it('selects the first valid execute path for the mix command', () => {
-        expect(autodetectExecutePath()).to.equal(`${validPath}/`);
+        beforeEach(() => {
+          process.env.PATH = `${validPath};C:\\Windows\\Useless\\Path`;
+          sandbox.stub(os, 'platform').returns('win32');
+          sandbox.replace(path, 'join', path.win32.join);
+          sandbox.replace(path, 'delimiter', path.win32.delimiter);
+          sandbox.replace(path, 'sep', path.win32.sep);
+          sandbox.stub(fs, 'existsSync').withArgs(`${validPath}\\mix.bat`).returns(true);
+        });
+
+        it('selects the first valid execute path for the mix command', () => {
+          expect(autodetectExecutePath()).to.equal(`${validPath}\\`);
+        });
       });
     });
 


### PR DESCRIPTION
**Problem:**

On Windows (i.e., win32 platforms), this extension outputs the warning: `...\mix is not executable`.

**Solution:**

If on a win32 platform, use the executable `mix.bat` in a given `executePath` instead of searching for a `mix` binary that does not exist.

Solves #10 