### PR TITLE
Respect Credo Configuration Regarding File Inclusion & Exclusion

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,7 @@
     "semi": "off",
     "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
     "max-len": ["error", { "code": 120 }],
-    "@typescript-eslint/no-unused-expressions": "off"
+    "@typescript-eslint/no-unused-expressions": "off",
+    "object-curly-newline": "off"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support this extension also on Windows platforms by using the mix executable `mix.bat`
-- Respect Credo's settings for including/excluding files when linting an Elixir file.
+- Support this extension also on Windows platforms by using the mix executable `mix.bat` (#10)
+- Respect Credo's settings for including/excluding files when linting an Elixir file. (#6)
   - Added a config named `lintEverything` that enables one to bypass the config's file inclusion/exclusion mechanism if set to `true`,
     and, thus, lint any Elixir file.
+
+### Changed
+
+- Forward any warning/error message coming from credo itself ([#8.1](https://github.com/pantajoe/vscode-elixir-credo/issues/8#issuecomment-797399444))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added a config named `lintEverything` that enables one to bypass the config's file inclusion/exclusion mechanism if set to `true`,
     and, thus, lint any Elixir file.
 
+### Fixed
+
+- Fixed a bug where no credo command was issued after a command was cancelled (when a document was closed/deleted, for instance)
+
 ## [0.2.0] - 2021-01-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support this extension also on Windows platforms by using the mix executable `mix.bat`
+- Respect Credo's settings for including/excluding files when linting an Elixir file.
+  - Added a config named `lintEverything` that enables one to bypass the config's file inclusion/exclusion mechanism if set to `true`,
+    and, thus, lint any Elixir file.
 
 ## [0.2.0] - 2021-01-12
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This extension contributes the following settings:
 * `elixir.credo.strictMode`: whether to utilize Credo's strict mode when linting.
 * `elixir.credo.executePath`: execute path of the `mix` executable
 * `elixir.credo.ignoreWarningMessages`: ignore warning messages (concerning finding the configuration file)
+* `elixir.credo.lintEverything`: lint any elixir file (even if excluded in the Credo configuration file)
 
 ### Known Issues
 

--- a/package.json
+++ b/package.json
@@ -78,6 +78,12 @@
             "description": "Ignore messages \"Found multiple files ...\", \"... file does not exist. Ignoring ...\"",
             "type": "boolean",
             "default": false
+          },
+          "elixir.credo.lintEverything": {
+            "title": "Lint Everything",
+            "description": "Lint every Elixir file, regardless of your .credo.exs config",
+            "type": "boolean",
+            "default": false
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "@types/vscode": "^1.47.0",
     "@typescript-eslint/eslint-plugin": "^2.30.0",
     "@typescript-eslint/parser": "^2.30.0",
+    "bdd-lazy-var": "^2.6.1",
     "chai": "^4.2.0",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-typescript": "^9.0.0",

--- a/src/CredoConfiguration.ts
+++ b/src/CredoConfiguration.ts
@@ -5,4 +5,5 @@ export default interface CredoConfiguration {
   credoConfiguration: string | 'default';
   strictMode: boolean;
   ignoreWarningMessages: boolean;
+  lintEverything: boolean;
 }

--- a/src/CredoOutput.ts
+++ b/src/CredoOutput.ts
@@ -15,3 +15,15 @@ export interface CredoIssue {
 export interface CredoOutput {
   issues: CredoIssue[];
 }
+
+export interface CredoInformation {
+  config: {
+    checks: string[],
+    files: string[],
+  };
+  system: {
+    credo: string,
+    elixir: string,
+    erlang: string,
+  };
+}

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -47,5 +47,6 @@ export function getConfig(): CredoConfiguration {
     credoConfiguration: conf.get('credoConfiguration', 'default'),
     strictMode: conf.get('strictMode', false),
     ignoreWarningMessages: conf.get('ignoreWarningMessages', false),
+    lintEverything: conf.get('lintEverything', false),
   };
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 // this extension's structure is heavily inspired by https://github.com/misogi/vscode-ruby-rubocop
 
 import * as vscode from 'vscode';
-import CredoProvider from './CredoProvider';
+import { CredoProvider } from './CredoProvider';
 import { getConfig } from './configuration';
 
 export function activate(context: vscode.ExtensionContext) {
@@ -9,7 +9,7 @@ export function activate(context: vscode.ExtensionContext) {
   const diagnosticCollection = vscode.languages.createDiagnosticCollection('elixir');
   context.subscriptions.push(diagnosticCollection);
 
-  const credo = new CredoProvider(diagnosticCollection);
+  const credo = new CredoProvider({ diagnosticCollection });
 
   workspace.onDidChangeConfiguration(() => {
     credo.config = getConfig();

--- a/src/taskQueue/Task.ts
+++ b/src/taskQueue/Task.ts
@@ -32,7 +32,7 @@ export default class Task {
 
   public run(): Promise<void> {
     if (this.isCanceled) {
-      return new Promise<void>(() => {});
+      return new Promise<void>((resolve) => { resolve(); });
     }
     const task = this;
     return new Promise<void>((resolve, _reject) => {

--- a/src/test/suite/CredoProvider.test.ts
+++ b/src/test/suite/CredoProvider.test.ts
@@ -25,6 +25,7 @@ describe('CredoProvider', () => {
           credoConfiguration: 'default',
           strictMode: false,
           ignoreWarningMessages: false,
+          lintEverything: false,
         }));
 
         it('returns true', () => {
@@ -43,6 +44,7 @@ describe('CredoProvider', () => {
           credoConfiguration: 'default',
           strictMode: false,
           ignoreWarningMessages: false,
+          lintEverything: false,
         }));
       });
 

--- a/src/test/suite/CredoProvider.test.ts
+++ b/src/test/suite/CredoProvider.test.ts
@@ -1,11 +1,25 @@
 import * as vscode from 'vscode';
-import { createSandbox, SinonSandbox } from 'sinon';
+import * as cp from 'child_process';
+import { createSandbox, SinonSandbox, SinonSpy, assert as sinonAssert } from 'sinon';
 import { expect } from 'chai';
+import { def } from 'bdd-lazy-var/global';
 import * as configurationModule from '../../configuration';
-import CredoProvider from '../../CredoProvider';
+import { CredoProvider } from '../../CredoProvider';
+import { CredoInformation, CredoOutput } from '../../CredoOutput';
+
+declare let $diagnosticCollection: vscode.DiagnosticCollection;
+declare let $credoProvider: CredoProvider;
+declare let $workspaceFilePath: string;
+declare let $fileName: string;
+declare let $documentUri: vscode.Uri;
+declare let $textDocument: vscode.TextDocument;
+declare let $credoOutput: CredoOutput;
+declare let $credoInfoOutput: CredoInformation;
 
 describe('CredoProvider', () => {
   let sandbox: SinonSandbox;
+  def('diagnosticCollection', () => vscode.languages.createDiagnosticCollection('elixir'));
+  def('credoProvider', () => new CredoProvider({ diagnosticCollection: $diagnosticCollection }));
 
   beforeEach(() => {
     sandbox = createSandbox();
@@ -13,6 +27,145 @@ describe('CredoProvider', () => {
 
   afterEach(() => {
     sandbox.restore();
+  });
+
+  context('#execute', () => {
+    def('workspaceFilePath', () => '/Users/bot/sample');
+    def('fileName', () => `${$workspaceFilePath}/lib/sample_web/telemetry.ex`);
+    def('documentUri', () => vscode.Uri.file($fileName));
+    def('textDocument', () => ({
+      languageId: 'elixir',
+      isUntitled: false,
+      uri: $documentUri,
+      fileName: $fileName,
+      getText: () => 'defmodule SampleWeb.Telemtry\n@var 2\nend\n',
+    }));
+    def('credoOutput', () => ({
+      issues: [{
+        category: 'readability',
+        check: 'Credo.Check.Readability.ModuleDoc',
+        column: 11,
+        column_end: 32,
+        filename: 'lib/sample_web/telemetry.ex',
+        line_no: 1,
+        message: 'Modules should have a @moduledoc tag.',
+        priority: 1,
+        trigger: 'SampleWeb.Telemetry',
+      }],
+    }));
+    def('credoInfoOutput', () => ({
+      config: {
+        checks: [],
+        files: [
+          'lib/sample_web/telemetry.ex',
+        ],
+      },
+      system: {
+        credo: '1.5.4-ref.main.9fe4739+uncommittedchanges',
+        elixir: '1.11.1',
+        erlang: '23',
+      },
+    }));
+
+    let setDiagnosticCollectionSpy: SinonSpy;
+    const execute = () => $credoProvider.execute($textDocument);
+
+    beforeEach(() => {
+      setDiagnosticCollectionSpy = sandbox.spy($diagnosticCollection, 'set');
+      sandbox.stub(vscode.workspace, 'getWorkspaceFolder').withArgs($documentUri).callsFake(() => ({
+        name: 'phoenix-project',
+        index: 0,
+        uri: vscode.Uri.file($workspaceFilePath),
+      }));
+      sandbox
+        .stub(cp, 'execFile')
+        .callsFake((_command, commandArguments, _options, callback) => {
+          if (callback) {
+            if (commandArguments?.includes('info')) {
+              callback(null, JSON.stringify($credoInfoOutput), '');
+            } else {
+              callback(null, JSON.stringify($credoOutput), '');
+            }
+          }
+
+          return { kill: () => {} } as cp.ChildProcess;
+        });
+    });
+
+    context('when lintEverything is true', () => {
+      beforeEach(() => {
+        sandbox.stub(configurationModule, 'getConfig').callsFake(() => ({
+          command: 'mix',
+          onSave: true,
+          configurationFile: '.credo.exs',
+          credoConfiguration: 'default',
+          strictMode: false,
+          ignoreWarningMessages: false,
+          lintEverything: true,
+        }));
+      });
+
+      it('correctly sets a diagnostic collection for the current document', () => {
+        execute();
+
+        sinonAssert.calledWith(
+          setDiagnosticCollectionSpy,
+          $documentUri,
+          [new vscode.Diagnostic(
+            new vscode.Range(0, 10, 0, 31),
+            'Modules should have a @moduledoc tag. (readability:Credo.Check.Readability.ModuleDoc)',
+            vscode.DiagnosticSeverity.Information,
+          )],
+        );
+        expect(setDiagnosticCollectionSpy.calledOnce).to.true;
+      });
+    });
+
+    context('when the extension only lints the files specified through the credo configuration file', () => {
+      beforeEach(() => {
+        sandbox.stub(configurationModule, 'getConfig').callsFake(() => ({
+          command: 'mix',
+          onSave: true,
+          configurationFile: '.credo.exs',
+          credoConfiguration: 'default',
+          strictMode: false,
+          ignoreWarningMessages: false,
+          lintEverything: false,
+        }));
+      });
+
+      context('when the current document should be linted', () => {
+        it('adds the diagnostic', () => {
+          execute();
+
+          sinonAssert.calledWith(
+            setDiagnosticCollectionSpy,
+            $documentUri,
+            [new vscode.Diagnostic(
+              new vscode.Range(0, 10, 0, 31),
+              'Modules should have a @moduledoc tag. (readability:Credo.Check.Readability.ModuleDoc)',
+              vscode.DiagnosticSeverity.Information,
+            )],
+          );
+          expect(setDiagnosticCollectionSpy.calledOnce).to.true;
+        });
+      });
+
+      context('when the current document should not be linted', () => {
+        def('fileName', () => `${$workspaceFilePath}/lib/sample_web/telemetry_test.ex`);
+
+        it('does not add any diagnostic', () => {
+          execute();
+
+          sinonAssert.calledWith(
+            setDiagnosticCollectionSpy,
+            $documentUri,
+            [],
+          );
+          expect(setDiagnosticCollectionSpy.calledOnce).to.true;
+        });
+      });
+    });
   });
 
   context('#isOnSave', () => {
@@ -27,11 +180,10 @@ describe('CredoProvider', () => {
           ignoreWarningMessages: false,
           lintEverything: false,
         }));
+      });
 
-        it('returns true', () => {
-          const credoProvider = new CredoProvider(vscode.languages.createDiagnosticCollection('elixir'));
-          expect(credoProvider.isOnSave).to.equal(true);
-        });
+      it('returns true', () => {
+        expect($credoProvider.isOnSave).to.equal(true);
       });
     });
 
@@ -49,8 +201,7 @@ describe('CredoProvider', () => {
       });
 
       it('returns false', () => {
-        const credoProvider = new CredoProvider(vscode.languages.createDiagnosticCollection('elixir'));
-        expect(credoProvider.isOnSave).to.equal(false);
+        expect($credoProvider.isOnSave).to.equal(false);
       });
     });
   });

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -8,7 +8,7 @@ export function run(): Promise<void> {
   // Create the mocha test
   const mocha = new Mocha({
     reporter: 'spec',
-    ui: 'bdd',
+    ui: 'bdd-lazy-var/global' as any,
     color: true,
   });
 

--- a/src/test/suite/taskQueue.test.ts
+++ b/src/test/suite/taskQueue.test.ts
@@ -23,41 +23,41 @@ class TestTaskWrapper {
   }
 }
 
-describe('TaskQueue', () => {
-  let queue: TaskQueue;
-  let taskWrapper: TestTaskWrapper;
-  let taskWrapper2: TestTaskWrapper;
+declare let $queue: TaskQueue;
+declare let $taskWrapper: TestTaskWrapper;
+declare let $taskWrapper2: TestTaskWrapper;
+declare let $taskWrapper3: TestTaskWrapper;
+declare let $anotherTaskWrapper: TestTaskWrapper;
 
-  beforeEach(() => {
-    queue = new TaskQueue();
-    taskWrapper = new TestTaskWrapper(vscode.Uri.file('/path/to/file'));
-    taskWrapper2 = new TestTaskWrapper(vscode.Uri.file('/path/to/file2'));
-  });
+describe('TaskQueue', () => {
+  def('queue', () => new TaskQueue());
+  def('taskWrapper', () => new TestTaskWrapper(vscode.Uri.file('/path/to/file')));
+  def('taskWrapper2', () => new TestTaskWrapper(vscode.Uri.file('/path/to/file2')));
 
   context('when one task is added to queue', () => {
     it('calles body', () => {
-      queue.enqueue(taskWrapper.task);
-      expect(taskWrapper.isBodyCalled).to.be.true;
-      expect(taskWrapper.token?.isCanceled).to.be.false;
-      expect(queue.length).to.eq(1);
+      $queue.enqueue($taskWrapper.task);
+      expect($taskWrapper.isBodyCalled).to.be.true;
+      expect($taskWrapper.token?.isCanceled).to.be.false;
+      expect($queue.length).to.eq(1);
     });
 
     it('can cancel running task', (done) => {
-      queue.enqueue(taskWrapper.task);
-      queue.cancel(taskWrapper.url);
-      expect(taskWrapper.isCancelCallbackCalled).to.be.true;
-      expect(taskWrapper.token?.isCanceled).to.be.true;
+      $queue.enqueue($taskWrapper.task);
+      $queue.cancel($taskWrapper.url);
+      expect($taskWrapper.isCancelCallbackCalled).to.be.true;
+      expect($taskWrapper.token?.isCanceled).to.be.true;
       setTimeout(() => {
-        expect(queue.length).to.eq(0);
+        expect($queue.length).to.eq(0);
         done();
       }, 0);
     });
 
     it('can finish task by calling finished()', (done) => {
-      queue.enqueue(taskWrapper.task);
-      taskWrapper.token?.finished();
+      $queue.enqueue($taskWrapper.task);
+      $taskWrapper.token?.finished();
       setTimeout(() => {
-        expect(queue.length).to.eq(0);
+        expect($queue.length).to.eq(0);
         done();
       }, 0);
     });
@@ -65,63 +65,67 @@ describe('TaskQueue', () => {
 
   context('when multiple tasks with different urls are added to queue', () => {
     it('calles body of only first task', () => {
-      queue.enqueue(taskWrapper.task);
-      queue.enqueue(taskWrapper2.task);
-      expect(taskWrapper.isBodyCalled).to.be.true;
-      expect(taskWrapper2.isBodyCalled).to.be.false;
-      expect(queue.length).to.eq(2);
+      $queue.enqueue($taskWrapper.task);
+      $queue.enqueue($taskWrapper2.task);
+      expect($taskWrapper.isBodyCalled).to.be.true;
+      expect($taskWrapper2.isBodyCalled).to.be.false;
+      expect($queue.length).to.eq(2);
     });
 
     it('run next task when first one is canceled', (done) => {
-      queue.enqueue(taskWrapper.task);
-      queue.enqueue(taskWrapper2.task);
-      expect(taskWrapper2.isBodyCalled).to.be.false;
-      queue.cancel(taskWrapper.url);
+      $queue.enqueue($taskWrapper.task);
+      $queue.enqueue($taskWrapper2.task);
+      expect($taskWrapper2.isBodyCalled).to.be.false;
+      $queue.cancel($taskWrapper.url);
       setTimeout(() => {
-        expect(taskWrapper2.isBodyCalled).to.be.true;
-        expect(queue.length).to.eq(1);
+        expect($taskWrapper2.isBodyCalled).to.be.true;
+        expect($queue.length).to.eq(1);
         done();
       }, 0);
     });
 
     it('run next task when first one is finished', (done) => {
-      queue.enqueue(taskWrapper.task);
-      queue.enqueue(taskWrapper2.task);
-      expect(taskWrapper2.isBodyCalled).to.be.false;
-      taskWrapper.token?.finished();
+      $queue.enqueue($taskWrapper.task);
+      $queue.enqueue($taskWrapper2.task);
+      expect($taskWrapper2.isBodyCalled).to.be.false;
+      $taskWrapper.token?.finished();
       setTimeout(() => {
-        expect(taskWrapper2.isBodyCalled).to.be.true;
-        expect(queue.length).to.eq(1);
+        expect($taskWrapper2.isBodyCalled).to.be.true;
+        expect($queue.length).to.eq(1);
         done();
       }, 0);
     });
 
-    it.skip('skip canceled task on selecting next task', (done) => {
-      const taskWrapper3 = new TestTaskWrapper(vscode.Uri.file('/path/to/file3'));
-      queue.enqueue(taskWrapper.task);
-      queue.enqueue(taskWrapper2.task);
-      queue.enqueue(taskWrapper3.task);
-      queue.cancel(taskWrapper2.url);
-      taskWrapper.token?.finished();
-      setTimeout(() => {
-        expect(taskWrapper2.isBodyCalled).to.be.false;
-        expect(taskWrapper3.isBodyCalled).to.be.true;
-        expect(queue.length).to.eq(1);
-        done();
-      }, 0);
+    context('when selecting next task', () => {
+      def('taskWrapper3', () => new TestTaskWrapper(vscode.Uri.file('/path/to/file3')));
+
+      it('skip canceled task on selecting next task', (done) => {
+        $queue.enqueue($taskWrapper.task);
+        $queue.enqueue($taskWrapper2.task);
+        $queue.enqueue($taskWrapper3.task);
+        $queue.cancel($taskWrapper2.url);
+        $taskWrapper.token?.finished();
+        setTimeout(() => {
+          expect($taskWrapper2.isBodyCalled).to.be.false;
+          expect($queue.length).to.eq(1);
+          expect($taskWrapper3.isBodyCalled).to.be.true;
+          done();
+        }, 0);
+      });
     });
   });
 
   context('when multiple tasks with same url are added to queue', () => {
+    def('anotherTaskWrapper', () => new TestTaskWrapper($taskWrapper.url));
+
     it('cancels former task', (done) => {
-      const anotherTaskWrapper = new TestTaskWrapper(taskWrapper.url);
-      queue.enqueue(taskWrapper.task);
-      expect(taskWrapper.isCancelCallbackCalled).to.be.false;
-      queue.enqueue(anotherTaskWrapper.task);
-      expect(taskWrapper.isCancelCallbackCalled).to.be.true;
+      $queue.enqueue($taskWrapper.task);
+      expect($taskWrapper.isCancelCallbackCalled).to.be.false;
+      $queue.enqueue($anotherTaskWrapper.task);
+      expect($taskWrapper.isCancelCallbackCalled).to.be.true;
       setTimeout(() => {
-        expect(anotherTaskWrapper.isBodyCalled).to.be.true;
-        expect(queue.length).to.eq(1);
+        expect($anotherTaskWrapper.isBodyCalled).to.be.true;
+        expect($queue.length).to.eq(1);
         done();
       }, 0);
     });
@@ -130,8 +134,8 @@ describe('TaskQueue', () => {
   context('when same task is enqueued twice', () => {
     it('throws error', () => {
       expect(() => {
-        queue.enqueue(taskWrapper.task);
-        queue.enqueue(taskWrapper.task);
+        $queue.enqueue($taskWrapper.task);
+        $queue.enqueue($taskWrapper.task);
       }).to.throw();
     });
   });

--- a/src/test/suite/utilities.test.ts
+++ b/src/test/suite/utilities.test.ts
@@ -75,8 +75,8 @@ describe('Utilities', () => {
           .to.true;
       });
 
-      it('does not include a --configuration-file argument', () => {
-        expect(getCommandArguments()).to.not.include('--configuration-file');
+      it('does not include a --config-file argument', () => {
+        expect(getCommandArguments()).to.not.include('--config-file');
       });
 
       context('if warning messages are ignored in config', () => {

--- a/src/test/suite/utilities.test.ts
+++ b/src/test/suite/utilities.test.ts
@@ -40,6 +40,7 @@ describe('Utilities', () => {
         credoConfiguration: 'default',
         strictMode: false,
         ignoreWarningMessages: false,
+        lintEverything: false,
       }));
     });
 
@@ -88,6 +89,7 @@ describe('Utilities', () => {
             credoConfiguration: 'default',
             strictMode: false,
             ignoreWarningMessages: true,
+            lintEverything: false,
           }));
         });
 
@@ -130,6 +132,7 @@ describe('Utilities', () => {
             credoConfiguration: 'default',
             strictMode: false,
             ignoreWarningMessages: true,
+            lintEverything: false,
           }));
         });
 
@@ -153,6 +156,7 @@ describe('Utilities', () => {
           credoConfiguration: 'default',
           strictMode: true,
           ignoreWarningMessages: false,
+          lintEverything: false,
         }));
       });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -383,6 +383,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+bdd-lazy-var@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/bdd-lazy-var/-/bdd-lazy-var-2.6.1.tgz#ca03fb36d68c5a507c0ba9a4d53160b899e6b7cb"
+  integrity sha512-X3ADwcFji/IHIrYJhTTpaiWhoOx4pl4whdAx1dmvdeUPsMUb7fVYFvf/Q33VEAEAVkEwi5rgNSZ0Y9oOVeQV+A==
+
 binary-extensions@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"


### PR DESCRIPTION
**Problem:**
Credo supports including or excluding certain files. Since this extension only feeds credo the document's content through stdin, credo could not respect that.

**Solution:**
Use `mix credo info` command to retrieve information about which files should be linted by parsing a file-path filelist.

This PR also adds a config option called `lintEverything` to  ignore the configuration's file settings and lint any opened/saved Elixir file.

Solves #6.