### PR TITLE
Add debug log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support multiple workspaces (#8)
 - Add an output channel to track the extension's processes
+  - Added a configuration option `enableDebug` that enables extensive logging to the output channel, such as
+    - configuration changes
+    - spawned processes
+    - credo CLI args
+    - etc.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This extension contributes the following settings:
 * `elixir.credo.executePath`: execute path of the `mix` executable
 * `elixir.credo.ignoreWarningMessages`: ignore warning messages (concerning finding the configuration file)
 * `elixir.credo.lintEverything`: lint any elixir file (even if excluded in the Credo configuration file)
+* `elixir.credo.enableDebug`: toggle extensive logging to extension's output channel
 
 ### Known Issues
 

--- a/package.json
+++ b/package.json
@@ -78,6 +78,12 @@
             "description": "Lint every Elixir file, regardless of your .credo.exs config",
             "type": "boolean",
             "default": false
+          },
+          "elixir.credo.enableDebug": {
+            "title": "Enable Debug Mode",
+            "description": "Enable extensive logging to the output channel",
+            "type": "boolean",
+            "default": false
           }
         }
       }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -15,6 +15,7 @@ export interface CredoConfiguration {
   strictMode: boolean;
   ignoreWarningMessages: boolean;
   lintEverything: boolean;
+  enableDebug: boolean;
 }
 
 export function autodetectExecutePath(): string {
@@ -53,5 +54,6 @@ export function getConfig(): CredoConfiguration {
     strictMode: conf.get('strictMode', false),
     ignoreWarningMessages: conf.get('ignoreWarningMessages', false),
     lintEverything: conf.get('lintEverything', false),
+    enableDebug: conf.get('enableDebug', false),
   };
 }

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -97,7 +97,7 @@ export function createLintDocumentCallback(
     const output = parseOutput<CredoOutput>(stdout);
     if (!output) return;
 
-    log({ message: `Setting linter issues for document '${uri.path}'.`, level: LogLevel.Info });
+    log({ message: `Setting linter issues for document '${uri.path}'.`, level: LogLevel.Debug });
     diagnosticCollection.set(uri, parseCredoOutput({ credoOutput: output, document }));
 
     token.finished();
@@ -112,7 +112,7 @@ function executeCredoProcess(
   log({
     message: trunc`Executing credo command \`${[ConfigurationProvider.instance.config.command, ...cmdArgs].join(' ')}\`
     for '${document.uri.path}'`,
-    level: LogLevel.Info,
+    level: LogLevel.Debug,
   });
 
   const credoProcess = cp.execFile(
@@ -148,7 +148,7 @@ export function executeCredo(
   log({
     message: trunc`Retreiving credo information: Executing credo command
     \`${[ConfigurationProvider.instance.config.command, ...CREDO_INFO_ARGS].join(' ')}\` for '${document.uri.path}'`,
-    level: LogLevel.Info,
+    level: LogLevel.Debug,
   });
   // eslint-disable-next-line max-len
   const infoProcess = cp.execFile(ConfigurationProvider.instance.config.command, CREDO_INFO_ARGS, options, (error, stdout, stderr) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,10 +13,7 @@ export function activate(context: vscode.ExtensionContext) {
   const credo = new CredoProvider({ diagnosticCollection });
 
   workspace.onDidChangeConfiguration(() => {
-    log({
-      message: 'Extension configuration has changed. Refreshing configuration ...',
-      level: LogLevel.Info,
-    });
+    log({ message: 'Extension configuration has changed. Refreshing configuration ...', level: LogLevel.Debug });
     ConfigurationProvider.instance.reloadConfig();
   });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,8 @@ export function activate(context: vscode.ExtensionContext) {
   workspace.onDidCloseTextDocument((document: vscode.TextDocument) => {
     credo.clear({ document });
   });
+
+  log({ message: 'Elixir Linter (Credo) initiated successfully.', level: LogLevel.Info });
 }
 
 export function deactivate() {}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,9 +2,10 @@ import * as vscode from 'vscode';
 import ConfigurationProvider from './ConfigurationProvider';
 
 export enum LogLevel {
-  Info = 0,
-  Warning = 1,
-  Error = 2,
+  Debug = 0,
+  Info = 1,
+  Warning = 2,
+  Error = 3,
 }
 
 export interface LogArguments {
@@ -14,17 +15,26 @@ export interface LogArguments {
 
 export const outputChannel = vscode.window.createOutputChannel('Elixir Linter (Credo)');
 
-export function log({ message, level = LogLevel.Error } : LogArguments) {
-  const { ignoreWarningMessages } = ConfigurationProvider.instance.config;
+function logToOutputChannel(message: string): void {
   outputChannel.appendLine(`> ${message}\n`);
+}
+
+export function log({ message, level = LogLevel.Error } : LogArguments) {
+  const { ignoreWarningMessages, enableDebug } = ConfigurationProvider.instance.config;
 
   switch (level) {
+    case LogLevel.Debug:
+      enableDebug && logToOutputChannel(message);
+      break;
     case LogLevel.Info:
+      logToOutputChannel(message);
       break;
     case LogLevel.Warning:
+      logToOutputChannel(message);
       !ignoreWarningMessages && vscode.window.showWarningMessage(message);
       break;
     case LogLevel.Error:
+      logToOutputChannel(message);
       vscode.window.showErrorMessage(message);
       break;
     default:

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -72,7 +72,7 @@ export class CredoProvider {
     if (isFileUri(uri)) {
       log({
         message: `Removing linter messages and cancel running linting processes for '${uri.path}'.`,
-        level: LogLevel.Info,
+        level: LogLevel.Debug,
       });
       this.taskQueue.cancel(uri);
       this.diagnosticCollection.delete(uri);

--- a/src/test/suite/ConfigurationProvider.test.ts
+++ b/src/test/suite/ConfigurationProvider.test.ts
@@ -26,6 +26,7 @@ describe('ConfigurationProvider', () => {
         strictMode: false,
         ignoreWarningMessages: false,
         lintEverything: false,
+        enableDebug: false,
       });
     });
 
@@ -65,6 +66,7 @@ describe('ConfigurationProvider', () => {
         strictMode: false,
         ignoreWarningMessages: false,
         lintEverything: false,
+        enableDebug: false,
       });
       const { config } = ConfigurationProvider.instance;
       configStub.restore();

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -32,6 +32,20 @@ describe('Extension Tests', () => {
 
     def('extensionContext', () => ({ subscriptions: [] }));
 
+    it('logs that the extension was activated successfully', () => {
+      const logSpy = sandbox.spy(loggerModule, 'log');
+
+      activateExtension();
+
+      sandbox.assert.calledWith(
+        logSpy,
+        {
+          message: 'Elixir Linter (Credo) initiated successfully.',
+          level: LogLevel.Info,
+        },
+      );
+    });
+
     context('when listening for configuration changes', () => {
       let eventListenerSpy: SinonSpy<any[], vscode.Disposable>;
       let configurationSpy: SinonSpy<[], void>;

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -71,7 +71,7 @@ describe('Extension Tests', () => {
 
         sandbox.assert.calledWith(logSpy, {
           message: 'Extension configuration has changed. Refreshing configuration ...',
-          level: LogLevel.Info,
+          level: LogLevel.Debug,
         });
       });
     });

--- a/src/test/suite/logger.test.ts
+++ b/src/test/suite/logger.test.ts
@@ -8,6 +8,7 @@ declare let $message: string;
 declare let $logLevel: LogLevel;
 declare let $config: CredoConfiguration;
 declare let $ignoreWarningMessages: boolean;
+declare let $enableDebug: boolean;
 
 describe('Loggging', () => {
   let sandbox: SinonSandbox;
@@ -17,6 +18,7 @@ describe('Loggging', () => {
 
   def('message', () => 'Sample message');
   def('ignoreWarningMessages', () => false);
+  def('enableDebug', () => false);
   def('config', () => ({
     command: 'mix',
     configurationFile: '.credo.exs',
@@ -24,6 +26,7 @@ describe('Loggging', () => {
     strictMode: false,
     ignoreWarningMessages: $ignoreWarningMessages,
     lintEverything: false,
+    enableDebug: $enableDebug,
   }));
 
   beforeEach(() => {
@@ -37,6 +40,26 @@ describe('Loggging', () => {
 
   afterEach(() => {
     sandbox.restore();
+  });
+
+  context('with a debug message', () => {
+    def('logLevel', () => LogLevel.Debug);
+
+    it('does not log the message to the output channel', () => {
+      logMessage();
+
+      sandbox.assert.notCalled(outputChannelSpy);
+    });
+
+    context('when enabling debug mode', () => {
+      def('enableDebug', () => true);
+
+      it('logs the message to the output channel', () => {
+        logMessage();
+
+        sandbox.assert.calledOnceWithExactly(outputChannelSpy, '> Sample message\n');
+      });
+    });
   });
 
   context('with an info message', () => {

--- a/src/test/suite/provider.test.ts
+++ b/src/test/suite/provider.test.ts
@@ -199,7 +199,7 @@ describe('CredoProvider', () => {
             logSpy,
             {
               message: "Setting linter issues for document '/Users/bot/sample/lib/sample_web/telemetry.ex'.",
-              level: loggerModule.LogLevel.Info,
+              level: loggerModule.LogLevel.Debug,
             },
           );
         });
@@ -224,7 +224,7 @@ describe('CredoProvider', () => {
             {
               // eslint-disable-next-line max-len
               message: "Executing credo command `mix credo --format json --read-from-stdin --config-name default` for '/Users/bot/sample/lib/sample_web/telemetry.ex'",
-              level: loggerModule.LogLevel.Info,
+              level: loggerModule.LogLevel.Debug,
             },
           );
         });
@@ -250,7 +250,7 @@ describe('CredoProvider', () => {
               {
                 // eslint-disable-next-line max-len
                 message: "Retreiving credo information: Executing credo command `mix credo info --format json --verbose` for '/Users/bot/sample/lib/sample_web/telemetry.ex'",
-                level: loggerModule.LogLevel.Info,
+                level: loggerModule.LogLevel.Debug,
               },
             ),
           ).to.be.false;
@@ -333,7 +333,7 @@ describe('CredoProvider', () => {
               logSpy,
               {
                 message: "Setting linter issues for document '/Users/bot/sample/lib/sample_web/telemetry.ex'.",
-                level: loggerModule.LogLevel.Info,
+                level: loggerModule.LogLevel.Debug,
               },
             );
           });
@@ -358,7 +358,7 @@ describe('CredoProvider', () => {
               {
                 // eslint-disable-next-line max-len
                 message: "Executing credo command `mix credo --format json --read-from-stdin --config-name default` for '/Users/bot/sample/lib/sample_web/telemetry.ex'",
-                level: loggerModule.LogLevel.Info,
+                level: loggerModule.LogLevel.Debug,
               },
             );
           });
@@ -383,7 +383,7 @@ describe('CredoProvider', () => {
               {
                 // eslint-disable-next-line max-len
                 message: "Retreiving credo information: Executing credo command `mix credo info --format json --verbose` for '/Users/bot/sample/lib/sample_web/telemetry.ex'",
-                level: loggerModule.LogLevel.Info,
+                level: loggerModule.LogLevel.Debug,
               },
             );
           });
@@ -410,7 +410,7 @@ describe('CredoProvider', () => {
               logSpy,
               {
                 message: "Setting linter issues for document '/Users/bot/sample/lib/sample_web/telemetry_test.ex'.",
-                level: loggerModule.LogLevel.Info,
+                level: loggerModule.LogLevel.Debug,
               },
             );
           });
@@ -435,7 +435,7 @@ describe('CredoProvider', () => {
               logSpy.calledWith({
                 // eslint-disable-next-line max-len
                 message: "Executing credo command `mix credo --format json --read-from-stdin --config-name default` for '/Users/bot/sample/lib/sample_web/telemetry_test.ex'",
-                level: loggerModule.LogLevel.Info,
+                level: loggerModule.LogLevel.Debug,
               }),
             ).to.be.false;
           });
@@ -460,7 +460,7 @@ describe('CredoProvider', () => {
               {
                 // eslint-disable-next-line max-len
                 message: "Retreiving credo information: Executing credo command `mix credo info --format json --verbose` for '/Users/bot/sample/lib/sample_web/telemetry_test.ex'",
-                level: loggerModule.LogLevel.Info,
+                level: loggerModule.LogLevel.Debug,
               },
             );
           });
@@ -506,7 +506,7 @@ describe('CredoProvider', () => {
         {
           // eslint-disable-next-line max-len
           message: "Removing linter messages and cancel running linting processes for '/Users/bot/sample/lib/sample_web/telemetry_test.ex'.",
-          level: loggerModule.LogLevel.Info,
+          level: loggerModule.LogLevel.Debug,
         },
       );
     });


### PR DESCRIPTION
**Problem:**

Since with every opening/saving a document multiple lines are logged to the output channel, it can get polluted.

**Solution:**

Add a log level `Debug` to avoid such pollution while still allowing info messages that yield no toast message.
Add a configuration option `enableDebug` that toggles mentioned extensive logging.