### PR TITLE
Support Windows (Part II)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-None.
+### Fixed
+
+- Fixed Windows Support (#18, #19)
 
 ## [0.4.0] - 2021-04-10
 

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -97,7 +97,7 @@ export function createLintDocumentCallback(
     const output = parseOutput<CredoOutput>(stdout);
     if (!output) return;
 
-    log({ message: `Setting linter issues for document '${uri.path}'.`, level: LogLevel.Debug });
+    log({ message: `Setting linter issues for document '${uri.fsPath}'.`, level: LogLevel.Debug });
     diagnosticCollection.set(uri, parseCredoOutput({ credoOutput: output, document }));
 
     token.finished();
@@ -111,7 +111,7 @@ function executeCredoProcess(
 ): cp.ChildProcess {
   log({
     message: trunc`Executing credo command \`${[ConfigurationProvider.instance.config.command, ...cmdArgs].join(' ')}\`
-    for '${document.uri.path}'`,
+    for '${document.uri.fsPath}'`,
     level: LogLevel.Debug,
   });
 
@@ -142,12 +142,12 @@ export function executeCredo(
   const processes = [];
   const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
   const relativeDocumentPath = workspaceFolder
-    ? document.fileName.replace(`${workspaceFolder.uri.path}${path.sep}`, '')
+    ? document.fileName.replace(`${workspaceFolder.uri.fsPath}${path.sep}`, '')
     : document.fileName;
 
   log({
     message: trunc`Retreiving credo information: Executing credo command
-    \`${[ConfigurationProvider.instance.config.command, ...CREDO_INFO_ARGS].join(' ')}\` for '${document.uri.path}'`,
+    \`${[ConfigurationProvider.instance.config.command, ...CREDO_INFO_ARGS].join(' ')}\` for '${document.uri.fsPath}'`,
     level: LogLevel.Debug,
   });
   // eslint-disable-next-line max-len

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -155,7 +155,12 @@ export function executeCredo(
     if (reportError({ error, stderr })) return;
 
     const credoInformation = parseOutput<CredoInformation>(stdout);
-    if (!credoInformation?.config?.files?.includes(relativeDocumentPath)) {
+    if (!credoInformation) return;
+
+    // file paths of credo are shown in UNIX style with a '/' path separator
+    credoInformation.config.files = credoInformation.config.files.map((filePath) => filePath.replace(/\//g, path.sep));
+
+    if (!credoInformation.config.files.includes(relativeDocumentPath)) {
       onFinishedExecution(null, '{ "issues": [] }', '');
       return;
     }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -71,7 +71,7 @@ export class CredoProvider {
     const { uri } = document;
     if (isFileUri(uri)) {
       log({
-        message: `Removing linter messages and cancel running linting processes for '${uri.path}'.`,
+        message: `Removing linter messages and cancel running linting processes for '${uri.fsPath}'.`,
         level: LogLevel.Debug,
       });
       this.taskQueue.cancel(uri);

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -42,7 +42,7 @@ export function getCommandArguments(): string[] {
 
   const found = [configurationFile].concat(
     (vscode.workspace.workspaceFolders || []).map(
-      (ws: vscode.WorkspaceFolder) => path.join(ws.uri.path, configurationFile),
+      (ws: vscode.WorkspaceFolder) => path.join(ws.uri.fsPath, configurationFile),
     ),
   ).filter((p: string) => fs.existsSync(p));
 


### PR DESCRIPTION
**Problem:**

On Windows, the paths specified by credo and by `vscode.Uri#path` always use `/` as a path separator.
This renders the extension useless (see #18):

- no configuration file found
- no linting occurs
- output logging uses wrong paths
- ...

**Solution:**

- use `vscode.Uri#fsPath` instead as it respects the current OS
- preprocess credo's file allowlist that is used to lint only the files specified through the credo config