### PR TITLE
fix: use the config file if it's an absolute path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-None.
+### Fixed
+
+- Only add the configuration file configured in the extension's configuration to all found configuration file
+  if it's an absolute path, the file exists, and it is not already found (#4)
 
 ## [0.4.4] - 2021-04-16
 

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -107,7 +107,7 @@ export function createLintDocumentCallback(
     const output = parseOutput<CredoOutput>(stdout);
     if (!output) return;
 
-    log({ message: `Setting linter issues for document '${uri.fsPath}'.`, level: LogLevel.Debug });
+    log({ message: `Setting linter issues for document ${uri.fsPath}.`, level: LogLevel.Debug });
     diagnosticCollection.set(uri, parseCredoOutput({ credoOutput: output, document }));
 
     token.finished();
@@ -121,7 +121,7 @@ function executeCredoProcess(
 ): cp.ChildProcess {
   log({
     message: trunc`Executing credo command \`${[ConfigurationProvider.instance.config.command, ...cmdArgs].join(' ')}\`
-    for '${document.uri.fsPath}' in directory '${options.cwd}'`,
+    for ${document.uri.fsPath} in directory ${options.cwd}`,
     level: LogLevel.Debug,
   });
 
@@ -157,8 +157,8 @@ export function executeCredo(
 
   log({
     message: trunc`Retreiving credo information: Executing credo command
-    \`${[ConfigurationProvider.instance.config.command, ...CREDO_INFO_ARGS].join(' ')}\` for '${document.uri.fsPath}'
-    in directory '${options.cwd}'`,
+    \`${[ConfigurationProvider.instance.config.command, ...CREDO_INFO_ARGS].join(' ')}\` for ${document.uri.fsPath}
+    in directory ${options.cwd}`,
     level: LogLevel.Debug,
   });
   // eslint-disable-next-line max-len

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -47,7 +47,7 @@ export class CredoProvider {
 
     const task = new Task(uri, (token) => {
       const processes = executeCredo({
-        cmdArgs: getCommandArguments(),
+        cmdArgs: getCommandArguments(document),
         document,
         options: {
           cwd: currentPath,

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -71,7 +71,7 @@ export class CredoProvider {
     const { uri } = document;
     if (isFileUri(uri)) {
       log({
-        message: `Removing linter messages and cancel running linting processes for '${uri.fsPath}'.`,
+        message: `Removing linter messages and cancel running linting processes for ${uri.fsPath}.`,
         level: LogLevel.Debug,
       });
       this.taskQueue.cancel(uri);

--- a/src/test/suite/provider.test.ts
+++ b/src/test/suite/provider.test.ts
@@ -198,7 +198,7 @@ describe('CredoProvider', () => {
           sinonAssert.calledWith(
             logSpy,
             {
-              message: "Setting linter issues for document '/Users/bot/sample/lib/sample_web/telemetry.ex'.",
+              message: 'Setting linter issues for document /Users/bot/sample/lib/sample_web/telemetry.ex.',
               level: loggerModule.LogLevel.Debug,
             },
           );
@@ -223,7 +223,7 @@ describe('CredoProvider', () => {
             logSpy,
             {
               // eslint-disable-next-line max-len
-              message: "Executing credo command `mix credo --format json --read-from-stdin --config-name default` for '/Users/bot/sample/lib/sample_web/telemetry.ex' in directory '/Users/bot/sample'",
+              message: 'Executing credo command `mix credo --format json --read-from-stdin --config-name default` for /Users/bot/sample/lib/sample_web/telemetry.ex in directory /Users/bot/sample',
               level: loggerModule.LogLevel.Debug,
             },
           );
@@ -249,7 +249,7 @@ describe('CredoProvider', () => {
             logSpy.calledWith(
               {
                 // eslint-disable-next-line max-len
-                message: "Retreiving credo information: Executing credo command `mix credo info --format json --verbose` for '/Users/bot/sample/lib/sample_web/telemetry.ex' in directory '/Users/bot/sample'",
+                message: 'Retreiving credo information: Executing credo command `mix credo info --format json --verbose` /Users/bot/sample/lib/sample_web/telemetry.ex in directory /Users/bot/sample',
                 level: loggerModule.LogLevel.Debug,
               },
             ),
@@ -332,7 +332,7 @@ describe('CredoProvider', () => {
             sinonAssert.calledWith(
               logSpy,
               {
-                message: "Setting linter issues for document '/Users/bot/sample/lib/sample_web/telemetry.ex'.",
+                message: 'Setting linter issues for document /Users/bot/sample/lib/sample_web/telemetry.ex.',
                 level: loggerModule.LogLevel.Debug,
               },
             );
@@ -357,7 +357,7 @@ describe('CredoProvider', () => {
               logSpy,
               {
                 // eslint-disable-next-line max-len
-                message: "Executing credo command `mix credo --format json --read-from-stdin --config-name default` for '/Users/bot/sample/lib/sample_web/telemetry.ex' in directory '/Users/bot/sample'",
+                message: 'Executing credo command `mix credo --format json --read-from-stdin --config-name default` for /Users/bot/sample/lib/sample_web/telemetry.ex in directory /Users/bot/sample',
                 level: loggerModule.LogLevel.Debug,
               },
             );
@@ -382,7 +382,7 @@ describe('CredoProvider', () => {
               logSpy,
               {
                 // eslint-disable-next-line max-len
-                message: "Retreiving credo information: Executing credo command `mix credo info --format json --verbose` for '/Users/bot/sample/lib/sample_web/telemetry.ex' in directory '/Users/bot/sample'",
+                message: 'Retreiving credo information: Executing credo command `mix credo info --format json --verbose` for /Users/bot/sample/lib/sample_web/telemetry.ex in directory /Users/bot/sample',
                 level: loggerModule.LogLevel.Debug,
               },
             );
@@ -409,7 +409,7 @@ describe('CredoProvider', () => {
             sinonAssert.calledWith(
               logSpy,
               {
-                message: "Setting linter issues for document '/Users/bot/sample/lib/sample_web/telemetry_test.ex'.",
+                message: 'Setting linter issues for document /Users/bot/sample/lib/sample_web/telemetry_test.ex.',
                 level: loggerModule.LogLevel.Debug,
               },
             );
@@ -434,7 +434,7 @@ describe('CredoProvider', () => {
             expect(
               logSpy.calledWith({
                 // eslint-disable-next-line max-len
-                message: "Executing credo command `mix credo --format json --read-from-stdin --config-name default` for '/Users/bot/sample/lib/sample_web/telemetry_test.ex' in directory '/Users/bot/sample'",
+                message: 'Executing credo command `mix credo --format json --read-from-stdin --config-name default` for /Users/bot/sample/lib/sample_web/telemetry_test.ex in directory /Users/bot/sample',
                 level: loggerModule.LogLevel.Debug,
               }),
             ).to.be.false;
@@ -459,7 +459,7 @@ describe('CredoProvider', () => {
               logSpy,
               {
                 // eslint-disable-next-line max-len
-                message: "Retreiving credo information: Executing credo command `mix credo info --format json --verbose` for '/Users/bot/sample/lib/sample_web/telemetry_test.ex' in directory '/Users/bot/sample'",
+                message: 'Retreiving credo information: Executing credo command `mix credo info --format json --verbose` for /Users/bot/sample/lib/sample_web/telemetry_test.ex in directory /Users/bot/sample',
                 level: loggerModule.LogLevel.Debug,
               },
             );
@@ -505,7 +505,7 @@ describe('CredoProvider', () => {
         logSpy,
         {
           // eslint-disable-next-line max-len
-          message: "Removing linter messages and cancel running linting processes for '/Users/bot/sample/lib/sample_web/telemetry_test.ex'.",
+          message: 'Removing linter messages and cancel running linting processes for /Users/bot/sample/lib/sample_web/telemetry_test.ex.',
           level: loggerModule.LogLevel.Debug,
         },
       );

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -40,11 +40,14 @@ export function getCommandArguments(): string[] {
   const extensionConfig = ConfigurationProvider.instance.config;
   const configurationFile = extensionConfig.configurationFile || DEFAULT_CONFIG_FILE;
 
-  const found = [configurationFile].concat(
-    (vscode.workspace.workspaceFolders || []).map(
-      (ws: vscode.WorkspaceFolder) => path.join(ws.uri.fsPath, configurationFile),
-    ),
-  ).filter((p: string) => fs.existsSync(p));
+  const found = (vscode.workspace.workspaceFolders || []).map(
+    (ws: vscode.WorkspaceFolder) => path.join(ws.uri.fsPath, configurationFile),
+  ).filter((fullPath: string) => fs.existsSync(fullPath));
+
+  // add unchanged value of `configurationFile` in case it is an absolute path
+  if (path.isAbsolute(configurationFile) && !found.includes(configurationFile) && fs.existsSync(configurationFile)) {
+    found.push(configurationFile);
+  }
 
   if (found.length === 0) {
     log({ message: `${configurationFile} file does not exist. Ignoring...`, level: LogLevel.Warning });


### PR DESCRIPTION
**Problem:**

Users are getting the error warning "found multiple configuration files" all the time

**Solution:**

Consider the configured `configurationFile` only if it's absolute, not found already and not present in the array consisting of the found configuration files

Closes #4.