### PR TITLE
feat: add support for diff mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-None.
+### Added
+
+- added Credo's [diff mode](https://hexdocs.pm/credo/diff_command.html#from-git-merge-base) against a merge base (#104)
+  - enable with setting `elixir.credo.diffMode.enabled`
+  - change the default merge base `"HEAD"` by using the setting `elixir.credo.diffMode.mergeBase`
 
 ## [0.7.3] - 2022-07-28
 
-## Added
+### Added
 
 - now searches for configuration file both in project root and `config/` directory (#81)
 
-## Unrelated changes
+### Unrelated changes
 
 - upgraded dependencies
 - use @antfu's eslint configuration

--- a/package.json
+++ b/package.json
@@ -110,6 +110,21 @@
             "description": "Enable extensive logging to the output channel",
             "type": "boolean",
             "default": false
+          },
+          "elixir.credo.diffMode.enabled": {
+            "title": "Enable Credo Diff Mode",
+            "markdownDescription": "Enable Credo's [diff mode](https://hexdocs.pm/credo/diff_command.html) against a [merge base](https://hexdocs.pm/credo/diff_command.html#from-git-merge-base).\n\nYou can specify the merge base in the setting `#elixir.credo.diffMode.mergeBase#`",
+            "type": "boolean",
+            "default": false,
+            "scope": "resource"
+          },
+          "elixir.credo.diffMode.mergeBase": {
+            "title": "Merge Base for Credo Diff Mode",
+            "markdownDescription": "Change the [merge base](https://hexdocs.pm/credo/diff_command.html#from-git-merge-base) for Credo's diff mode (e.g., `main`).",
+            "type": "string",
+            "if": "config.elixir.credo.diffMode.enabled",
+            "default": "HEAD",
+            "scope": "resource"
           }
         }
       }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 import * as os from 'os'
 import * as vscode from 'vscode'
 
-const MIX_COMMAND = {
+const MixCommand = {
   unix: 'mix',
   win32: 'mix.bat',
 }
@@ -18,6 +18,10 @@ export interface CredoConfiguration {
   enableDebug: boolean
   checksWithTag: string[]
   checksWithoutTag: string[]
+  diffMode: {
+    enabled: boolean
+    mergeBase: string
+  }
 }
 
 export function autodetectExecutePath(): string {
@@ -36,7 +40,7 @@ export function autodetectExecutePath(): string {
 
   pathParts.forEach((pathPart) => {
     const binPath =
-      os.platform() === 'win32' ? path.join(pathPart, MIX_COMMAND.win32) : path.join(pathPart, MIX_COMMAND.unix)
+      os.platform() === 'win32' ? path.join(pathPart, MixCommand.win32) : path.join(pathPart, MixCommand.unix)
 
     if (fs.existsSync(binPath)) executePath = pathPart + path.sep
   })
@@ -46,7 +50,7 @@ export function autodetectExecutePath(): string {
 
 export function fetchConfig(): CredoConfiguration {
   const conf = vscode.workspace.getConfiguration('elixir.credo')
-  const mixCommand = os.platform() === 'win32' ? MIX_COMMAND.win32 : MIX_COMMAND.unix
+  const mixCommand = os.platform() === 'win32' ? MixCommand.win32 : MixCommand.unix
 
   return {
     command: `${autodetectExecutePath()}${mixCommand}`,
@@ -58,6 +62,10 @@ export function fetchConfig(): CredoConfiguration {
     ignoreWarningMessages: conf.get('ignoreWarningMessages', false),
     lintEverything: conf.get('lintEverything', false),
     enableDebug: conf.get('enableDebug', false),
+    diffMode: {
+      enabled: conf.get('diffMode.enabled', false),
+      mergeBase: conf.get('diffMode.mergeBase', 'HEAD'),
+    },
   }
 }
 

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -1,14 +1,14 @@
 import * as cp from 'child_process'
 import * as path from 'path'
 import * as vscode from 'vscode'
-import type { CredoCommandOutput, CredoInformation, CredoOutput } from './output'
+import type { CredoCommandOutput, CredoDiffOutput, CredoInformation, CredoOutput } from './output'
 import type { TaskToken } from './task-queue'
 import { parseCredoOutput } from './parser'
 import { LogLevel, log } from './logger'
 import { getCurrentConfiguration } from './configuration'
 import { trunc } from './utilities'
 
-const CREDO_INFO_ARGS = ['credo', 'info', '--format', 'json', '--verbose']
+const CredoInfoCommand = ['credo', 'info', '--format', 'json', '--verbose']
 
 type LintDocumentCallback = (error: cp.ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void
 
@@ -112,7 +112,7 @@ export function createLintDocumentCallback({
 
     diagnosticCollection.delete(uri)
 
-    const output = parseOutput<CredoOutput>(stdout)
+    const output = parseOutput<CredoOutput | CredoDiffOutput>(stdout)
     if (!output) return
 
     log({ message: `Setting linter issues for document ${uri.fsPath}.`, level: LogLevel.Debug })
@@ -166,14 +166,14 @@ export function executeCredo({
 
   log({
     message: trunc`Retreiving credo information: Executing credo command
-    \`${[getCurrentConfiguration().command, ...CREDO_INFO_ARGS].join(' ')}\` for ${document.uri.fsPath}
+    \`${[getCurrentConfiguration().command, ...CredoInfoCommand].join(' ')}\` for ${document.uri.fsPath}
     in directory ${options.cwd}`,
     level: LogLevel.Debug,
   })
 
   const infoProcess = cp.execFile(
     getCurrentConfiguration().command,
-    CREDO_INFO_ARGS,
+    CredoInfoCommand,
     options,
     (error, stdout, stderr) => {
       if (reportError({ error, stderr })) return

--- a/src/output.ts
+++ b/src/output.ts
@@ -16,6 +16,14 @@ export interface CredoOutput {
   issues: CredoIssue[]
 }
 
+export interface CredoDiffOutput {
+  diff: {
+    fixed: CredoIssue[]
+    new: CredoIssue[]
+    old: CredoIssue[]
+  }
+}
+
 export interface CredoInformation {
   config: {
     checks: string[]
@@ -28,4 +36,8 @@ export interface CredoInformation {
   }
 }
 
-export type CredoCommandOutput = CredoInformation | CredoOutput
+export type CredoCommandOutput = CredoInformation | CredoOutput | CredoDiffOutput
+
+export const isDiffOutput = (output: CredoOutput | CredoDiffOutput): output is CredoDiffOutput => {
+  return 'diff' in output
+}

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
-import type { CredoIssue, CredoOutput, CredoSeverity } from './output'
+import type { CredoDiffOutput, CredoIssue, CredoOutput, CredoSeverity } from './output'
+import { isDiffOutput } from './output'
 import { makeZeroBasedIndex } from './utilities'
 
 function parseSeverity(credoSeverity: CredoSeverity): vscode.DiagnosticSeverity {
@@ -66,9 +67,10 @@ export function parseCredoOutput({
   credoOutput,
   document,
 }: {
-  credoOutput: CredoOutput
+  credoOutput: CredoOutput | CredoDiffOutput
   document: vscode.TextDocument
 }): vscode.Diagnostic[] {
   const documentContent = document.getText()
-  return credoOutput.issues.map((issue: CredoIssue) => parseCredoIssue({ issue, documentContent }))
+  const issues = isDiffOutput(credoOutput) ? credoOutput.diff.new : credoOutput.issues
+  return issues.map((issue: CredoIssue) => parseCredoIssue({ issue, documentContent }))
 }

--- a/src/test/suite/configuration.test.ts
+++ b/src/test/suite/configuration.test.ts
@@ -83,6 +83,10 @@ describe('Configuration', () => {
           ignoreWarningMessages: false,
           lintEverything: false,
           enableDebug: false,
+          diffMode: {
+            enabled: false,
+            mergeBase: 'HEAD',
+          },
         })
       })
 
@@ -119,6 +123,10 @@ describe('Configuration', () => {
           ignoreWarningMessages: false,
           lintEverything: false,
           enableDebug: false,
+          diffMode: {
+            enabled: false,
+            mergeBase: 'HEAD',
+          },
         }
         fetchConfigStub = sandbox.stub(configurationModule, 'fetchConfig').returns(initialConfig)
         reloadConfig()

--- a/src/test/suite/logger.test.ts
+++ b/src/test/suite/logger.test.ts
@@ -33,6 +33,10 @@ describe('Loggging', () => {
       ignoreWarningMessages: $ignoreWarningMessages,
       lintEverything: false,
       enableDebug: $enableDebug,
+      diffMode: {
+        enabled: false,
+        mergeBase: 'HEAD',
+      },
     }),
   )
 

--- a/src/test/suite/provider.test.ts
+++ b/src/test/suite/provider.test.ts
@@ -12,7 +12,7 @@ import * as loggerModule from '../../logger'
 import * as utilModule from '../../utilities'
 import type { CredoProviderOptions } from '../../provider'
 import { CredoProvider } from '../../provider'
-import type { CredoInformation, CredoOutput } from '../../output'
+import type { CredoDiffOutput, CredoInformation, CredoOutput } from '../../output'
 
 declare let $config: configurationModule.CredoConfiguration
 declare let $diagnosticCollection: vscode.DiagnosticCollection
@@ -23,7 +23,7 @@ declare let $fileName: string
 declare let $documentUri: vscode.Uri
 declare let $textDocument: vscode.TextDocument
 declare let $otherDocument: vscode.TextDocument
-declare let $credoOutput: CredoOutput
+declare let $credoOutput: CredoOutput | CredoDiffOutput
 declare let $credoInfoOutput: CredoInformation
 
 describe('CredoProvider', () => {
@@ -270,6 +270,97 @@ describe('CredoProvider', () => {
               level: loggerModule.LogLevel.Debug,
             }),
           ).to.be.false
+        })
+
+        context('with diff mode enabled', () => {
+          def('config', () => ({
+            command: 'mix',
+            configurationFile: '.credo.exs',
+            credoConfiguration: 'default',
+            checksWithTag: [],
+            checksWithoutTag: [],
+            strictMode: false,
+            ignoreWarningMessages: false,
+            lintEverything: true,
+            enableDebug: false,
+            diffMode: {
+              enabled: true,
+              mergeBase: 'main',
+            },
+          }))
+          def('credoOutput', () => ({
+            diff: {
+              old: [],
+              fixed: [],
+              new: [
+                {
+                  category: 'readability',
+                  check: 'Credo.Check.Readability.ModuleDoc',
+                  column: 11,
+                  column_end: 32,
+                  filename: 'lib/sample_web/telemetry.ex',
+                  line_no: 1,
+                  message: 'Modules should have a @moduledoc tag.',
+                  priority: 1,
+                  trigger: 'SampleWeb.Telemetry',
+                },
+              ],
+            },
+          }))
+
+          it('correctly sets a diagnostic collection for the current document', () => {
+            execute()
+
+            sinonAssert.calledWith(setDiagnosticCollectionSpy, $documentUri, [
+              new vscode.Diagnostic(
+                new vscode.Range(0, 10, 0, 31),
+                'Modules should have a @moduledoc tag. (readability:Credo.Check.Readability.ModuleDoc)',
+                vscode.DiagnosticSeverity.Information,
+              ),
+            ])
+            expect(setDiagnosticCollectionSpy.calledOnce).to.true
+          })
+
+          it('logs an info message when setting diagnostics', () => {
+            execute()
+
+            sinonAssert.calledWith(logSpy, {
+              message: 'Setting linter issues for document /Users/bot/sample/lib/sample_web/telemetry.ex.',
+              level: loggerModule.LogLevel.Debug,
+            })
+          })
+
+          it('executes credo', () => {
+            execute()
+
+            sinonAssert.calledWith(
+              execFileStub,
+              'mix',
+              [
+                'credo',
+                'diff',
+                '--format',
+                'json',
+                '--read-from-stdin',
+                '--config-name',
+                'default',
+                '--from-git-merge-base',
+                'main',
+              ],
+              match.any,
+              match.any,
+            )
+          })
+
+          it('logs that credo is being executed', () => {
+            execute()
+
+            sinonAssert.calledWith(logSpy, {
+              message:
+                'Executing credo command `mix credo diff --format json --read-from-stdin --config-name default --from-git-merge-base main` for /Users/bot/sample/lib/sample_web/telemetry.ex in directory /Users/bot/sample',
+              level: loggerModule.LogLevel.Debug,
+            })
+          })
         })
 
         context('with multiple opened workspaces', () => {

--- a/src/test/suite/provider.test.ts
+++ b/src/test/suite/provider.test.ts
@@ -201,6 +201,10 @@ describe('CredoProvider', () => {
             ignoreWarningMessages: false,
             lintEverything: true,
             enableDebug: false,
+            diffMode: {
+              enabled: false,
+              mergeBase: 'HEAD',
+            },
           }),
         )
 
@@ -322,6 +326,10 @@ describe('CredoProvider', () => {
             ignoreWarningMessages: false,
             lintEverything: false,
             enableDebug: false,
+            diffMode: {
+              enabled: false,
+              mergeBase: 'HEAD',
+            },
           }),
         )
 

--- a/src/test/suite/utilities.test.ts
+++ b/src/test/suite/utilities.test.ts
@@ -372,6 +372,42 @@ describe('Utilities', () => {
       })
     })
 
+    context('with diff mode enabled', () => {
+      def(
+        'config',
+        (): configurationModule.CredoConfiguration => ({
+          command: 'mix',
+          configurationFile: '.credo.exs',
+          credoConfiguration: 'default',
+          checksWithTag: [],
+          checksWithoutTag: [],
+          strictMode: true,
+          ignoreWarningMessages: false,
+          lintEverything: false,
+          enableDebug: false,
+          diffMode: {
+            enabled: true,
+            mergeBase: 'main',
+          },
+        }),
+      )
+
+      it('supplies the diff command with --from-git-merge-base', () => {
+        assert.match(getCommandArguments(), [
+          'credo',
+          'diff',
+          '--format',
+          'json',
+          '--read-from-stdin',
+          '--config-name',
+          'default',
+          '--strict',
+          '--from-git-merge-base',
+          'main',
+        ])
+      })
+    })
+
     context('with configured tags', () => {
       def('checksWithTag', () => [])
       def('checksWithoutTag', () => [])

--- a/src/test/suite/utilities.test.ts
+++ b/src/test/suite/utilities.test.ts
@@ -197,6 +197,10 @@ describe('Utilities', () => {
         ignoreWarningMessages: false,
         lintEverything: false,
         enableDebug: false,
+        diffMode: {
+          enabled: false,
+          mergeBase: 'HEAD',
+        },
       }),
     )
 
@@ -356,6 +360,10 @@ describe('Utilities', () => {
           ignoreWarningMessages: false,
           lintEverything: false,
           enableDebug: false,
+          diffMode: {
+            enabled: false,
+            mergeBase: 'HEAD',
+          },
         }),
       )
 
@@ -379,6 +387,10 @@ describe('Utilities', () => {
           ignoreWarningMessages: false,
           lintEverything: false,
           enableDebug: false,
+          diffMode: {
+            enabled: false,
+            mergeBase: 'HEAD',
+          },
         }),
       )
 


### PR DESCRIPTION
Closes #104 

**Added Functionality**:

- added Credo's [diff mode](https://hexdocs.pm/credo/diff_command.html#from-git-merge-base) against a merge base
  - enable with setting `elixir.credo.diffMode.enabled`
  - change the default merge base `"HEAD"` by using the setting `elixir.credo.diffMode.mergeBase`