### PR TITLE
feat: Allow to ignore error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This extension contributes the following settings:
 * `elixir.credo.checksWithTag`: specify tags of those checks which should be used in VS Code (all other checks will be ignored)
 * `elixir.credo.checksWithoutTag`: specify tags of checks which should be ignored in VS Code
 * `elixir.credo.ignoreWarningMessages`: ignore warning messages (concerning finding the configuration file)
+* `elixir.credo.ignoreErrorMessages`: ignore error messages
 * `elixir.credo.lintEverything`: lint any elixir file (even if excluded in the Credo configuration file)
 * `elixir.credo.enableDebug`: toggle extensive logging to extension's output channel
 * `elixir.credo.diffMode.enabled`: enable Credo's diff mode

--- a/package.json
+++ b/package.json
@@ -98,6 +98,12 @@
             "type": "boolean",
             "default": false
           },
+          "elixir.credo.ignoreErrorMessages": {
+            "title": "Ignore Error Messages",
+            "markdownDescription": "Ignore error messages like `Error on parsing output ...`",
+            "type": "boolean",
+            "default": false
+          },
           "elixir.credo.lintEverything": {
             "title": "Lint Everything",
             "markdownDescription": "Lint every Elixir file, regardless of your `.credo.exs` config",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -14,6 +14,7 @@ export interface CredoConfiguration {
   credoConfiguration: string | 'default'
   strictMode: boolean
   ignoreWarningMessages: boolean
+  ignoreErrorMessages: boolean
   lintEverything: boolean
   enableDebug: boolean
   checksWithTag: string[]
@@ -60,6 +61,7 @@ export function fetchConfig(): CredoConfiguration {
     checksWithTag: conf.get('checksWithTag', []),
     checksWithoutTag: conf.get('checksWithoutTag', []),
     ignoreWarningMessages: conf.get('ignoreWarningMessages', false),
+    ignoreErrorMessages: conf.get('ignoreErrorMessages', false),
     lintEverything: conf.get('lintEverything', false),
     enableDebug: conf.get('enableDebug', false),
     diffMode: {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -20,7 +20,7 @@ function logToOutputChannel(message: string): void {
 }
 
 export function log({ message, level = LogLevel.Error }: LogArguments) {
-  const { ignoreWarningMessages, enableDebug } = getCurrentConfiguration()
+  const { ignoreWarningMessages, ignoreErrorMessages, enableDebug } = getCurrentConfiguration()
 
   switch (level) {
     case LogLevel.Debug:
@@ -35,7 +35,7 @@ export function log({ message, level = LogLevel.Error }: LogArguments) {
       break
     case LogLevel.Error:
       logToOutputChannel(message)
-      vscode.window.showErrorMessage(message)
+      !ignoreErrorMessages && vscode.window.showErrorMessage(message)
       break
     default:
       break

--- a/src/test/suite/configuration.test.ts
+++ b/src/test/suite/configuration.test.ts
@@ -81,6 +81,7 @@ describe('Configuration', () => {
           checksWithoutTag: [],
           strictMode: false,
           ignoreWarningMessages: false,
+          ignoreErrorMessages: false,
           lintEverything: false,
           enableDebug: false,
           diffMode: {
@@ -98,6 +99,7 @@ describe('Configuration', () => {
           credoConfiguration,
           strictMode,
           ignoreWarningMessages,
+          ignoreErrorMessages,
           lintEverything,
           enableDebug,
         } = configurationModule.getCurrentConfiguration()
@@ -106,6 +108,7 @@ describe('Configuration', () => {
         expect(credoConfiguration).to.equal('default')
         expect(strictMode).to.be.false
         expect(ignoreWarningMessages).to.be.false
+        expect(ignoreErrorMessages).to.be.false
         expect(lintEverything).to.be.false
         expect(enableDebug).to.be.false
       })
@@ -121,6 +124,7 @@ describe('Configuration', () => {
           checksWithoutTag: [],
           strictMode: false,
           ignoreWarningMessages: false,
+          ignoreErrorMessages: false,
           lintEverything: false,
           enableDebug: false,
           diffMode: {

--- a/src/test/suite/logger.test.ts
+++ b/src/test/suite/logger.test.ts
@@ -8,6 +8,7 @@ declare let $message: string
 declare let $logLevel: LogLevel
 declare let $config: configurationModule.CredoConfiguration
 declare let $ignoreWarningMessages: boolean
+declare let $ignoreErrorMessages: boolean
 declare let $enableDebug: boolean
 
 describe('Loggging', () => {
@@ -20,6 +21,7 @@ describe('Loggging', () => {
 
   def('message', () => 'Sample message')
   def('ignoreWarningMessages', () => false)
+  def('ignoreErrorMessages', () => false)
   def('enableDebug', () => false)
   def(
     'config',
@@ -31,6 +33,7 @@ describe('Loggging', () => {
       checksWithoutTag: [],
       strictMode: false,
       ignoreWarningMessages: $ignoreWarningMessages,
+      ignoreErrorMessages: $ignoreErrorMessages,
       lintEverything: false,
       enableDebug: $enableDebug,
       diffMode: {
@@ -174,6 +177,22 @@ describe('Loggging', () => {
         logMessage()
 
         sandbox.assert.calledOnceWithExactly(vscodeMessageSpy, 'Sample message')
+      })
+    })
+
+    context('when ignoring error messages', () => {
+      def('ignoreErrorMessages', () => true)
+
+      it('logs the message to the output channel', () => {
+        logMessage()
+
+        sandbox.assert.calledOnceWithExactly(outputChannelSpy, '> Sample message\n')
+      })
+
+      it('does not show an error popup', () => {
+        logMessage()
+
+        sandbox.assert.notCalled(vscodeMessageSpy)
       })
     })
   })

--- a/src/test/suite/provider.test.ts
+++ b/src/test/suite/provider.test.ts
@@ -199,6 +199,7 @@ describe('CredoProvider', () => {
             checksWithoutTag: [],
             strictMode: false,
             ignoreWarningMessages: false,
+            ignoreErrorMessages: false,
             lintEverything: true,
             enableDebug: false,
             diffMode: {
@@ -273,21 +274,25 @@ describe('CredoProvider', () => {
         })
 
         context('with diff mode enabled', () => {
-          def('config', () => ({
-            command: 'mix',
-            configurationFile: '.credo.exs',
-            credoConfiguration: 'default',
-            checksWithTag: [],
-            checksWithoutTag: [],
-            strictMode: false,
-            ignoreWarningMessages: false,
-            lintEverything: true,
-            enableDebug: false,
-            diffMode: {
-              enabled: true,
-              mergeBase: 'main',
-            },
-          }))
+          def(
+            'config',
+            (): configurationModule.CredoConfiguration => ({
+              command: 'mix',
+              configurationFile: '.credo.exs',
+              credoConfiguration: 'default',
+              checksWithTag: [],
+              checksWithoutTag: [],
+              strictMode: false,
+              ignoreWarningMessages: false,
+              ignoreErrorMessages: false,
+              lintEverything: true,
+              enableDebug: false,
+              diffMode: {
+                enabled: true,
+                mergeBase: 'main',
+              },
+            }),
+          )
           def('credoOutput', () => ({
             diff: {
               old: [],
@@ -415,6 +420,7 @@ describe('CredoProvider', () => {
             checksWithoutTag: [],
             strictMode: false,
             ignoreWarningMessages: false,
+            ignoreErrorMessages: false,
             lintEverything: false,
             enableDebug: false,
             diffMode: {

--- a/src/test/suite/utilities.test.ts
+++ b/src/test/suite/utilities.test.ts
@@ -223,6 +223,7 @@ describe('Utilities', () => {
         checksWithoutTag: [],
         strictMode: false,
         ignoreWarningMessages: false,
+        ignoreErrorMessages: false,
         lintEverything: false,
         enableDebug: false,
         diffMode: {
@@ -391,6 +392,7 @@ describe('Utilities', () => {
           checksWithoutTag: [],
           strictMode: true,
           ignoreWarningMessages: false,
+          ignoreErrorMessages: false,
           lintEverything: false,
           enableDebug: false,
           diffMode: {
@@ -416,6 +418,7 @@ describe('Utilities', () => {
           checksWithoutTag: [],
           strictMode: true,
           ignoreWarningMessages: false,
+          ignoreErrorMessages: false,
           lintEverything: false,
           enableDebug: false,
           diffMode: {
@@ -454,6 +457,7 @@ describe('Utilities', () => {
           checksWithoutTag: $checksWithoutTag,
           strictMode: false,
           ignoreWarningMessages: false,
+          ignoreErrorMessages: false,
           lintEverything: false,
           enableDebug: false,
           diffMode: {


### PR DESCRIPTION
This PR adds an `ignoreErrorMessages` option that allows us to ignore those `Error on parsing output` messages that can be quite distracting.

Closes #344 