### PR TITLE
feat: ignore SIGTERM errors

### DIFF
--- a/src/execution.ts
+++ b/src/execution.ts
@@ -45,9 +45,14 @@ export function parseOutput<T extends CredoCommandOutput>(stdout: string | Buffe
 
     return JSON.parse(extractedJSON)
   } catch (e) {
-    if (e instanceof SyntaxError) {
+    const outputLog = output.replace(/[\r\n \t]/g, ' ')
+
+    // It's probably safe to ignore SIGTERM errors: https://en.wikipedia.org/wiki/Signal_(IPC)#SIGTERM
+    const isSIGTERM = outputLog.includes('SIGTERM')
+
+    if (e instanceof SyntaxError && !isSIGTERM) {
       log({
-        message: `Error on parsing output (It might be non-JSON output): "${output.replace(/[\r\n \t]/g, ' ')}"`,
+        message: `Error on parsing output (It might be non-JSON output): "${outputLog}"`,
         level: LogLevel.Error,
       })
     }

--- a/src/test/suite/execution.test.ts
+++ b/src/test/suite/execution.test.ts
@@ -63,6 +63,20 @@ describe('Credo Execution Functions', () => {
         })
       })
 
+      context('with SIGTERM output', () => {
+        def('output', () => '[notice] SIGTERM received - shutting down')
+
+        it('returns null', () => {
+          expect(parse()).to.be.null
+        })
+
+        it('does not log anything', () => {
+          parse()
+
+          expect(logSpy.notCalled).to.be.true
+        })
+      })
+
       context('with valid JSON output', () => {
         def(
           'output',
@@ -139,6 +153,20 @@ describe('Credo Execution Functions', () => {
             level: loggerModule.LogLevel.Error,
             message: 'Error on parsing output (It might be non-JSON output): "No JSON"',
           })
+        })
+      })
+
+      context('with SIGTERM output', () => {
+        def('output', () => '[notice] SIGTERM received - shutting down')
+
+        it('returns null', () => {
+          expect(parse()).to.be.null
+        })
+
+        it('does not log anything', () => {
+          parse()
+
+          expect(logSpy.notCalled).to.be.true
         })
       })
 


### PR DESCRIPTION
I think it's probably safe to ignore [SIGTERM](https://en.wikipedia.org/wiki/Signal_(IPC)#SIGTERM) errors and (considering how annoying they are) I propose we do it.

Fixes #349 